### PR TITLE
add support for global `ai` command through `npm i -g`

### DIFF
--- a/openai.js
+++ b/openai.js
@@ -1,14 +1,14 @@
+#!/usr/bin/env node
+
 const { EOL } = require('os')
 const { Configuration, OpenAIApi } = require('openai')
 const { createInterface } = require('readline')
 const say = require('say')
 const cld = require('cld')
-const configuration = new Configuration({ apiKey: process.env.npm_config_openai_secret })
+const configuration = new Configuration({ apiKey: process.env.npm_config_openai_secret || process.env.OPENAI_API_KEY })
 const ai = new OpenAIApi(configuration)
 const rl = createInterface({ input: process.stdin, output: process.stdout })
 const lang = require('./lang.json')
-
-console.log(process.argv,)
 
 setImmediate(function qa(ai, rl) {
   rl.question('> ', async (prompt) => {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "author": "Ivo von Putzer Reibegg <ivo.putzer@gmail.com> (https://github.com/ivoputzer)",
   "description": "This is a simple slack app/bot that makes use of gpt3 🤣",
   "main": "index.js",
+  "bin": {
+    "ai": "./openai.js"
+  },
   "scripts": {
     "prompt": "node openai.js",
     "start": "node index.js",

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,8 @@ To have a global `ai` command available to interact with OpenAI, do the followin
 1. `gh repo clone ivoputzer/slack.codin.gg`
 2. `cd slack.codin.gg`
 3. Run `npm i -g .` to install the `ai` command globally
-4. Run `ai` and you'll be presented an interactive CLI to interact with OpenAI 
+4. To run the command `ai` from anywhere, setup the environment variable `OPENAI_API_KEY`
+5. Run `ai` and you'll be presented an interactive CLI to interact with OpenAI 
 
 ## Contribute
 Fork the repo open PR and get in touch 📬

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ To have a global `ai` command available to interact with OpenAI, do the followin
 1. `gh repo clone ivoputzer/slack.codin.gg`
 2. `cd slack.codin.gg`
 3. Run `npm i -g .` to install the `ai` command globally
-4. To run the command `ai` from anywhere, setup the environment variable `OPENAI_API_KEY`
+4. To run the command `ai` from anywhere, setup the environment variable `OPENAI_API_KEY` or edit global configuration located at `~/.npmrc`
 5. Run `ai` and you'll be presented an interactive CLI to interact with OpenAI 
 
 ## Contribute

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,16 @@ npm run prompt --openai_secret=<open-ai-secret>
 npm run prompt --openai_secret=<open-ai-secret> -- --tts
 ```
 
+
+## install `ai` command
+
+To have a global `ai` command available to interact with OpenAI, do the following (to be improved with npm install -g)
+
+1. `gh repo clone ivoputzer/slack.codin.gg`
+2. `cd slack.codin.gg`
+3. Run `npm i -g .` to install the `ai` command globally
+4. Run `ai` and you'll be presented an interactive CLI to interact with OpenAI 
+
 ## Contribute
 Fork the repo open PR and get in touch 📬
 


### PR DESCRIPTION
added a bit of documentation on how to configure the cli
changed the `openai.js` to support the environment var `OPENAI_API_KEY` + remove debug log